### PR TITLE
Remove references to "adult works" page

### DIFF
--- a/src/pages/adults.tsx
+++ b/src/pages/adults.tsx
@@ -120,18 +120,6 @@ const AdultsClass = () => {
                     <b>豊富な資料</b>{' '}
                     教室内に沢山のアート系の本があり、貸し出しもしています。
                   </Text>
-                  <Button
-                    as={Link}
-                    variant="outline"
-                    href={'/adults-works'}
-                    fontWeight={600}
-                    color={'text'}
-                    _hover={{
-                      bg: 'gray.100'
-                    }}
-                  >
-                    制作例
-                  </Button>
                 </CardBody>
               </Card>
               <Card mt={'1em'} mb={'1em'} minW={'100%'}>

--- a/tools/populate-cdn.sh
+++ b/tools/populate-cdn.sh
@@ -38,20 +38,6 @@ wget -O "adults-headercarousel-3.jpg" https://farm5.staticflickr.com/4647/274113
 wget -O "adults-body-1.jpg" https://farm6.staticflickr.com/5012/5421765280_d8293bb143_z.jpg
 wget -O "adults-body-2.jpg" https://farm9.staticflickr.com/8478/8178105894_ff9a3f6418_z.jpg
 
-# Page: adults-works
-wget -O "adults-works-1.jpg" https://live.staticflickr.com/5220/5421436344_baa63dc0c0.jpg
-wget -O "adults-works-2.jpg" https://live.staticflickr.com/5275/5847184438_3e8801d176.jpg
-wget -O "adults-works-3.jpg" https://live.staticflickr.com/6086/6154523420_d158bdf72d.jpg
-wget -O "adults-works-4.jpg" https://live.staticflickr.com/6060/6320863046_ceb2fcf71c.jpg
-wget -O "adults-works-5.jpg" https://live.staticflickr.com/8009/7307465518_554a96b993.jpg
-wget -O "adults-works-6.jpg" https://live.staticflickr.com/6115/6366976179_32f887a3c1.jpg
-wget -O "adults-works-7.jpg" https://live.staticflickr.com/7147/6429964155_1e30a371d4.jpg
-wget -O "adults-works-8.jpg" https://live.staticflickr.com/8047/8077027588_272bb69be7.jpg
-wget -O "adults-works-8.jpg" https://live.staticflickr.com/8240/8571857146_a22fdfdd00.jpg
-wget -O "adults-works-10.jpg" https://live.staticflickr.com/8485/8237097430_6eca3a40b9.jpg
-wget -O "adults-works-11.jpg" https://live.staticflickr.com/8536/8684355741_4a7fb96b65.jpg
-wget -O "adults-works-12.jpg" https://live.staticflickr.com/3753/8753586608_498f133625.jpg
-
 # ClassPlace slides: generic
 wget -O "placeslide-otona.jpg" https://www.studiokura.com/kasuga.studiokura.com/img/itoshima-otona.jpg
 wget -O "placeslide-kodomo.jpg" https://www.studiokura.com/kasuga.studiokura.com/img/itoshima-kodomo.jpg


### PR DESCRIPTION
Close https://github.com/studio-kura/studiokura-com-nextjs/issues/14

- Remove "adult works" images from CDN population script
- Remove link to "adult works" page
